### PR TITLE
Fix failing test after UI update

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/welcome to text embedding/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update test expectation to match the login page heading

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699f5a4a54832b9008d4ace24a764f